### PR TITLE
Update deprecated_sanitizer.rb

### DIFF
--- a/lib/rails/deprecated_sanitizer.rb
+++ b/lib/rails/deprecated_sanitizer.rb
@@ -1,6 +1,6 @@
 require "rails/deprecated_sanitizer/version"
 require "rails/deprecated_sanitizer/html-scanner"
-require "rails/deprecated_sanitizer/railtie"
+require "rails/deprecated_sanitizer/railtie" if defined?(Rails::Railtie)
 
 module Rails
   module DeprecatedSanitizer


### PR DESCRIPTION
Hi,

I found this gem doesn't work in some Rails environment without railtie. I actually found this  issue because my Gem only depends on actionmailer. Could you fix this issue?

```
/opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rails-deprecated_sanitizer-1.0.2/lib/rails/deprecated_sanitizer/railtie.rb:1:in `require': cannot load such file -- rails/railtie (LoadError)
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rails-deprecated_sanitizer-1.0.2/lib/rails/deprecated_sanitizer/railtie.rb:1:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rails-deprecated_sanitizer-1.0.2/lib/rails/deprecated_sanitizer.rb:4:in `require'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rails-deprecated_sanitizer-1.0.2/lib/rails/deprecated_sanitizer.rb:4:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rails-deprecated_sanitizer-1.0.2/lib/rails-deprecated_sanitizer.rb:1:in `require'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rails-deprecated_sanitizer-1.0.2/lib/rails-deprecated_sanitizer.rb:1:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/sanitize_helper.rb:3:in `require'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/sanitize_helper.rb:3:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/text_helper.rb:32:in `<module:TextHelper>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/text_helper.rb:29:in `<module:Helpers>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/text_helper.rb:6:in `<module:ActionView>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/text_helper.rb:4:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/form_tag_helper.rb:18:in `<module:FormTagHelper>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/form_tag_helper.rb:14:in `<module:Helpers>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/form_tag_helper.rb:8:in `<module:ActionView>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/form_tag_helper.rb:6:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/form_helper.rb:4:in `require'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers/form_helper.rb:4:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers.rb:50:in `<module:Helpers>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers.rb:4:in `<module:ActionView>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/helpers.rb:3:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/base.rb:5:in `require'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/base.rb:5:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/view_paths.rb:1:in `require'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionview-4.2.0.beta1/lib/action_view/view_paths.rb:1:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionpack-4.2.0.beta1/lib/abstract_controller/rendering.rb:4:in `require'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionpack-4.2.0.beta1/lib/abstract_controller/rendering.rb:4:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionmailer-4.2.0.beta1/lib/action_mailer/base.rb:408:in `<class:Base>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionmailer-4.2.0.beta1/lib/action_mailer/base.rb:402:in `<module:ActionMailer>'
    from /opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/actionmailer-4.2.0.beta1/lib/action_mailer/base.rb:9:in `<top (required)>'
```
