### PR TITLE
Update README.md to reflect what's in Rails 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Rails::Deprecated::Sanitizer
 
-In Rails 4.2 the sanitization implementation uses Loofah by default.
-Previously html-scanner was used for this.
-This gem includes that old behavior for easier migration and it will be supported until Rails 5.
+In Rails 4.2 a new and more secure sanitization implementation option has been introduced.
+It is the default implementation for new applications generated in Rails 4.2 and
+all applications in Rails 5.
 
-If you need this behavior, add the gem to an applications gemfile, run `bundle` and the deprecated behavior is installed.
+This gem includes the old behavior shipping with Rails 4.2 and before. It will be supported until Rails 5.
 
-    gem 'rails-deprecated_sanitizer'
+# Upgrading Your Application
+To upgrade to the new behavior today, upgrade your Rails app to 4.2, add the `rails-html-sanitizer`
+gem to your Gemfile, run `bundle` and you're all set.
+Consult the Rails 4.2 upgrade guide for more information.
 
-You can read more about the new behavior here: [rails-html-sanitizer](https://github.com/rails/rails-html-sanitizer).
+You can read more about the new sanitization implementation here: [rails-html-sanitizer](https://github.com/rails/rails-html-sanitizer).
 
 # Reporting XSS Security Issues
 


### PR DESCRIPTION
Fixes #2.
- Rails Html Sanitizer is not the default, this gem is.
- Explain when this gem is no longer the default.
- Add Rails 5 information.
